### PR TITLE
Simplify common exponent

### DIFF
--- a/coffeequate/src/operators/Mul.coffee
+++ b/coffeequate/src/operators/Mul.coffee
@@ -309,6 +309,25 @@ define [
 			if constantterm?.evaluate?() == 0
 				return new terminals.Constant("0")
 
+			newLikeTerms = []
+			for term0 in liketerms
+				[base0, power0] = term0
+				
+				found = false
+				for term1 in newLikeTerms
+					[base1, power1] = term1
+					
+					if power1.equals?(power0, equivalencies)
+						unless base1 instanceof Mul
+							base1 = new Mul(base1)
+							term1[0] = base1
+						base1.children.push(base0)
+						found = true
+						break
+				
+				newLikeTerms.push(term0) unless found
+			liketerms = newLikeTerms
+
 			newMul = null
 			for liketerm in liketerms
 				if liketerm[1].evaluate?() != 1

--- a/coffeequate/src/operators/Mul.coffee
+++ b/coffeequate/src/operators/Mul.coffee
@@ -314,19 +314,21 @@ define [
 				[base0, power0] = term0
 				
 				found = false
-				for term1 in newLikeTerms
-					[base1, power1] = term1
-					
-					if power1.equals?(power0, equivalencies)
-						unless base1 instanceof Mul
-							base1 = new Mul(base1)
-							term1[0] = base1
-						base1.children.push(base0)
-						found = true
-						break
+				unless power0.evaluate?() == 1
+					for term1 in newLikeTerms
+						[base1, power1] = term1
+						
+						if power1.equals?(power0, equivalencies)
+							base1.push(base0)
+							found = true
+							break
 				
-				newLikeTerms.push(term0) unless found
-			liketerms = ([base.expandAndSimplify(), power] for [base, power] in newLikeTerms)
+				newLikeTerms.push([[base0], power0]) unless found
+			liketerms = ([
+				(if base.length == 1 then base[0] else new Mul(base...))
+					.expandAndSimplify(),
+				power
+			] for [base, power] in newLikeTerms)
 
 			newMul = null
 			for liketerm in liketerms

--- a/coffeequate/src/operators/Mul.coffee
+++ b/coffeequate/src/operators/Mul.coffee
@@ -326,7 +326,7 @@ define [
 						break
 				
 				newLikeTerms.push(term0) unless found
-			liketerms = newLikeTerms
+			liketerms = ([base.expandAndSimplify(), power] for [base, power] in newLikeTerms)
 
 			newMul = null
 			for liketerm in liketerms


### PR DESCRIPTION
`CQ('a**2 + b**2 = c**2').solve('a')` yields the slightly awkward result +/-`sqrt(-(1))*sqrt(b**2 - c**2)`

This patch collects common exponents in multiplication, resulting in +/-`sqrt(c**2 - b**2)`