### PR TITLE
add Expression.equals

### DIFF
--- a/src/Expression.coffee
+++ b/src/Expression.coffee
@@ -156,4 +156,13 @@ define ["parse", "nodes"], (parse, nodes) ->
 
 			return fun
 
+		equals: (other) ->
+			return undefined unless other instanceof Expression
+
+			# convert to canonical form
+			lhs = @expr.expandAndSimplify()
+			rhs = other.expr.expandAndSimplify()
+
+			return lhs.equals(rhs)
+
 	return Expression


### PR DESCRIPTION
Adds a `.equals` method for expressions.  See #111